### PR TITLE
update makemessages regex to match django's translate tag

### DIFF
--- a/src/cdh/core/management/commands/makemessages.py
+++ b/src/cdh/core/management/commands/makemessages.py
@@ -15,7 +15,7 @@ def templatize(src, **kwargs):
 
     template.inline_re = re.compile(
         # Match the trans 'some text' part
-        r"""^\s*trans(?:format)?\s+((?:"[^"]*?")|(?:'[^']*?'))"""
+        r"""^\s*trans(?:format|late)?\s+((?:"[^"]*?")|(?:'[^']*?'))"""
         # Match and ignore optional filters
         r"""(?:\s*\|\s*[^\s:]+(?::(?:[^\s'":]+|(?:"[^"]*?")|(?:'[^']*?')))?)*"""
         # Match the optional context part


### PR DESCRIPTION
Django's documentation currently features the `{% translate %}` tags instead of the old `{% trans %}`
(see https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#translate-template-tag 
and https://github.com/django/django/commit/d291c72bf24387e4abe8d9883ebe9c69abdd26d0)

But `makemessages` can't find these tags when shared core is installed.